### PR TITLE
Downgrade version data

### DIFF
--- a/downgrading.html
+++ b/downgrading.html
@@ -333,6 +333,8 @@ THERE IS A HIGH CHANCE OF BRICK WITH THE CURRENT METHOD, UNLESS YOU FOLLOW THESE
   <li>Select "Start NUS Download!"</li>
   <li>When done, select: Database &gt; System (DSi) &gt; System Settings &gt; [Your Region] &gt; v512 </li>
   <li>Select "Start NUS Download!"</li>
+  <li>When done, select: Database &gt; System (DSi) &gt; Version Data &gt; [Your Region] &gt; v4 (China) </li>
+  <li>Select "Start NUS Download!"</li>
   <li>Install and open OSFMount</li>
   <li>Click the "Mount new..." button, followed by the "Image File" tick mark</li>
   <li>Press the button with the three periods (...) and select NAND_DEC.bin</li>
@@ -352,6 +354,10 @@ THERE IS A HIGH CHANCE OF BRICK WITH THE CURRENT METHOD, UNLESS YOU FOLLOW THESE
   <li>Open the folder called "titles" in the NUSDownloader_v19_DSi directory of your PC, open the folder named "00030015484e42[XX]", and open the folder named "512"</li>
   <li>Copy "00000002.app" and "tmd.512" from the folder you are now in, and paste them in the "title\00030015\484e42[XX]\content" folder on your new drive in your computer</li>
   <li>Rename "tmd.512 to "title.tmd".</li>
+  <li>Delete anything inside of the "title\0003000f\484e4c45\content" directory of the new drive. </li>
+  <li>Open the folder called "titles" in the NUSDownloader_v19_DSi directory of your PC, open the folder named "0003000f484e4c[XX]", and open the folder named "4"</li>
+  <li>Copy "00000004.app" and "tmd.4" from the folder you are now in, and paste them in the "title\0003000f\484e4c[XX]\content" folder on your new drive in your computer</li>
+  <li>Rename "tmd.4" to "title.tmd".</li>
   <li>Go to your OSFMount window, and press "Dismount". Exit OSFMount.
   </li><li>In the folder named twltool-v1.6, press shift and right click in an empty space and select "Open command window here" or "Open Powershell Window here", then paste in Code 2 (from our new Codes.txt) and press Enter</li>
   <li>When it is done, you should see a file named "NAND_ENC.bin" in the "twltool-v1.6" folder</li>


### PR DESCRIPTION
People in the Nintendo Homebrew server are consistently asking why their System Settings is still showing 1.4.5. When you downgrade a system, your natural expectation is that the System Settings will reflect the downgrade. Not only are people getting confused, but in some cases they're even believing that they did the process incorrectly, and it's getting tiring to tell them that they did nothing wrong and that the guide just doesn't have you downgrade version data.

This pull request would fix all of that.