### PR TITLE
Clean Links from dsiguide.me to dsiguide.github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # dsiguide.github.io (formerly www.dsiguide.me)
-<a href="https://www.dsiguide.github.io">Visit the guide here</a>
+<a href="https://dsiguide.github.io">Visit the guide here</a>
 
 This guide is a DSi Homebrew guide that allows you to go from stock firmware to HiyaCFW, a type of custom firmware.
 This is a guide for anyone that would like to have easy-to-follow instructions that they can understand, unlike other, more complicated guides.

--- a/credits.html
+++ b/credits.html
@@ -28,8 +28,8 @@
 <meta property="og:title" content="Credits">
 
 
-  <link rel="canonical" href="https://dsiguide.me/credits.html">
-  <meta property="og:url" content="https://dsiguide.me/credits.html">
+  <link rel="canonical" href="/credits.html">
+  <meta property="og:url" content="/credits.html">
 
 
 
@@ -76,7 +76,7 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="https://dsiguide.me/assets/css/main.css">
+<link rel="stylesheet" href="/assets/css/main.css">
 
 <meta http-equiv="cleartype" content="on">
 
@@ -85,7 +85,7 @@
 <!-- insert favicons. use http://realfavicongenerator.net/ -->
 
 <script type="text/javascript">
-    var host = "dsiguide.me";
+    var host = "dsiguide.github.io";
     if ((host == window.location.host) && (window.location.protocol != "https:"))
         window.location.protocol = "https";
 </script>
@@ -138,7 +138,7 @@
 
 
 
-<!--script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!--script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 <script>
   (adsbygoogle = window.adsbygoogle || []).push({
     google_ad_client: "ca-pub-6670011780914577",
@@ -183,7 +183,7 @@
         <hr>
 
         <center>
-        <!--script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+        <!--script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
         <!-- Guide -->
         <!--ins class="adsbygoogle"
             style="display:block"
@@ -307,12 +307,12 @@ Translation Team - site availible in other languages soon
 
 
 
-<div class="page__footer-copyright">&copy; 2018 LukeHasAWii, <a href="https://www.dsiguide.me/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
+<div class="page__footer-copyright">&copy; 2018 LukeHasAWii, <a href="/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
 
       </footer>
     </div>
 
-    <script src="https://dsiguide.me/assets/js/main.min.js"></script>
+    <script src="/assets/js/main.min.js"></script>
 
 
 

--- a/donations.html
+++ b/donations.html
@@ -28,8 +28,8 @@
 <meta property="og:title" content="Donations">
 
 
-  <link rel="canonical" href="https://dsiguide.me/donations.html">
-  <meta property="og:url" content="https://dsiguide.me/donations.html">
+  <link rel="canonical" href="/donations.html">
+  <meta property="og:url" content="/donations.html">
 
 
 
@@ -56,7 +56,7 @@
       "@context" : "http://schema.org",
       "@type" : "Person",
       "name" : "LukeHasAWii",
-      "url" : "https://dsiguide.me",
+      "url" : "https://dsiguide.github.io",
       "sameAs" : null
     }
   </script>
@@ -85,7 +85,7 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="https://dsiguide.me/assets/css/main.css">
+<link rel="stylesheet" href="/assets/css/main.css">
 
 <meta http-equiv="cleartype" content="on">
 
@@ -94,7 +94,7 @@
 <!-- insert favicons. use http://realfavicongenerator.net/ -->
 
 <script type="text/javascript">
-    var host = "dsiguide.me";
+    var host = "dsiguide.github.io";
     if ((host == window.location.host) && (window.location.protocol != "https:"))
         window.location.protocol = "https";
 </script>
@@ -211,12 +211,12 @@ I do not accept ethereum donations at this time.</p>
 
 
 
-<div class="page__footer-copyright">&copy; 2018 LukeHasAWii, <a href="https://www.dsiguide.me/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
+<div class="page__footer-copyright">&copy; 2018 LukeHasAWii, <a href="/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
 
       </footer>
     </div>
 
-    <script src="https://dsiguide.me/assets/js/main.min.js"></script>
+    <script src="/assets/js/main.min.js"></script>
 
 
 

--- a/downgrading-easy.html
+++ b/downgrading-easy.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- saved from url=(0031)https://dsiguide.me/downgrading -->
+<!-- saved from url=(0031)//downgrading -->
 <html lang="en" class="no-js"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     
 
@@ -28,8 +28,8 @@
 <meta property="og:title" content="Downgrading (ugopwn- TWLnf)">
 
 
-  <link rel="canonical" href="https://dsiguide.me/downgrading-easy/">
-  <meta property="og:url" content="https://dsiguide.me/downgrading-easy/">
+  <link rel="canonical" href="/downgrading-easy/">
+  <meta property="og:url" content="/downgrading-easy/">
 
 
 
@@ -56,7 +56,7 @@
       "@context" : "http://schema.org",
       "@type" : "Person",
       "name" : "LukeHasAWii",
-      "url" : "https://dsiguide.me",
+      "url" : "https://dsiguide.github.io",
       "sameAs" : null
     }
   </script>
@@ -80,7 +80,7 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="https://dsiguide.me/assets/css/main.css">
+<link rel="stylesheet" href="/assets/css/main.css">
 
 <meta http-equiv="cleartype" content="on">
 
@@ -89,16 +89,16 @@
 <!-- insert favicons. use http://realfavicongenerator.net/ -->
 
 <script type="text/javascript">
-    var host = "dsiguide.me";
+    var host = "dsiguide.github.io";
     if ((host == window.location.host) && (window.location.protocol != "https:"))
         window.location.protocol = "https";
 </script>
 
-<link rel="apple-touch-icon" sizes="180x180" href="https://dsiguide.me/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="https://dsiguide.me/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="https://dsiguide.me/favicon-16x16.png">
-<link rel="manifest" href="https://dsiguide.me/manifest.json">
-<link rel="mask-icon" href="https://dsiguide.me/safari-pinned-tab.svg" color="#5bbad5">
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+<link rel="manifest" href="/manifest.json">
+<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
 <meta name="theme-color" content="#ffffff">
 <!-- end custom head snippets -->
 
@@ -141,7 +141,7 @@
 
 
 
-<!--script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!--script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 <script>
   (adsbygoogle = window.adsbygoogle || []).push({
     google_ad_client: "ca-pub-6670011780914577",
@@ -264,7 +264,7 @@
                         <li>Power on your DSi, navigate to System Settings, and verify that your system version is now 1.4.</li>
                     </ol>
 
-                    <p class="notice--primary">Continue to <a href="https://www.dsiguide.me/hiyacfw-installation">Installing HiyaCFW</a>
+                    <p class="notice--primary">Continue to <a href="/hiyacfw-installation">Installing HiyaCFW</a>
 
                     </p>
                 </section>
@@ -287,12 +287,12 @@
 
 
 
-<div class="page__footer-copyright">© 2018 LukeHasAWii, Jerbear64 for this page (THANKS SO MUCH!), <a href="https://www.dsiguide.me/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="https://dsiguide.me/site-navigation">Site Navigation</a>
+<div class="page__footer-copyright">© 2018 LukeHasAWii, Jerbear64 for this page (THANKS SO MUCH!), <a href="/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="/site-navigation">Site Navigation</a>
 
       </div></footer>
     </div>
 
-      <script src="https://dsiguide.me/assets/js/main.min.js"></script>
+      <script src="/assets/js/main.min.js"></script>
 
 
 

--- a/downgrading.html
+++ b/downgrading.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- saved from url=(0031)https://dsiguide.me/downgrading -->
+<!-- saved from url=(0031)//downgrading -->
 <html lang="en" class=" js "><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     
 
@@ -28,8 +28,8 @@
 <meta property="og:title" content="Downgrading (ugopwn)">
 
 
-  <link rel="canonical" href="https://dsiguide.me/downgrading/">
-  <meta property="og:url" content="https://dsiguide.me/downgrading/">
+  <link rel="canonical" href="/downgrading/">
+  <meta property="og:url" content="/downgrading/">
 
 
 
@@ -56,7 +56,7 @@
       "@context" : "http://schema.org",
       "@type" : "Person",
       "name" : "LukeHasAWii",
-      "url" : "https://dsiguide.me",
+      "url" : "https://dsiguide.github.io",
       "sameAs" : null
     }
   </script>
@@ -80,7 +80,7 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="https://dsiguide.me/assets/css/main.css">
+<link rel="stylesheet" href="/assets/css/main.css">
 
 <meta http-equiv="cleartype" content="on">
 
@@ -89,16 +89,16 @@
 <!-- insert favicons. use http://realfavicongenerator.net/ -->
 
 <script type="text/javascript">
-    var host = "dsiguide.me";
+    var host = "dsiguide.github.io";
     if ((host == window.location.host) && (window.location.protocol != "https:"))
         window.location.protocol = "https";
 </script>
 
-<link rel="apple-touch-icon" sizes="180x180" href="https://dsiguide.me/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="https://dsiguide.me/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="https://dsiguide.me/favicon-16x16.png">
-<link rel="manifest" href="https://dsiguide.me/manifest.json">
-<link rel="mask-icon" href="https://dsiguide.me/safari-pinned-tab.svg" color="#5bbad5">
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+<link rel="manifest" href="/manifest.json">
+<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
 <meta name="theme-color" content="#ffffff">
 <!-- end custom head snippets -->
 
@@ -141,7 +141,7 @@
 
 
 
-<!--script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!--script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 <script>
   (adsbygoogle = window.adsbygoogle || []).push({
     google_ad_client: "ca-pub-6670011780914577",
@@ -180,13 +180,13 @@
 <div class="notice"><b>If you need help, ask the <a href="https://discord.gg/w4SKAr8">Nintendo DSiBrew Discord!</a></b></div>
         
           
-        <div class="notice"><b>I worked hard on this guide! If you want, you can <a href="https://dsiguide.me/donations">donate</a> through <a href="https://www.paypal.me/lukehasawii/10">PayPal</a> or <a href="bitcoin:126mXsRyQ8qmuqYQ86X3fhTvXL5B3SH877">Bitcoin</a>!</b></div>
+        <div class="notice"><b>I worked hard on this guide! If you want, you can <a href="/donations">donate</a> through <a href="https://www.paypal.me/lukehasawii/10">PayPal</a> or <a href="bitcoin:126mXsRyQ8qmuqYQ86X3fhTvXL5B3SH877">Bitcoin</a>!</b></div>
         
 
         <!--hr>
 
         <!--center>
-        <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
         <!-- Guide -->
         <!--ins class="adsbygoogle"
             style="display:block"
@@ -395,8 +395,8 @@ THERE IS A HIGH CHANCE OF BRICK WITH THE CURRENT METHOD, UNLESS YOU FOLLOW THESE
     
 </li></ol>
 
-<p class="notice--primary">Continue to <a href="https://dsiguide.me/hiyacfw-installation">Installing HiyaCFW</a>
-<p class="notice--primary">If you would like a way to access DSi Homebrew without having to use ugopwn every time, follow the procedure for <a href="https://dsiguide.me/exploit_installation.html">Installing exploitable DSiWare</a>
+<p class="notice--primary">Continue to <a href="/hiyacfw-installation">Installing HiyaCFW</a>
+<p class="notice--primary">If you would like a way to access DSi Homebrew without having to use ugopwn every time, follow the procedure for <a href="/exploit_installation.html">Installing exploitable DSiWare</a>
         <!--center>
         <ins class="adsbygoogle"
             style="display:block"
@@ -444,7 +444,7 @@ THERE IS A HIGH CHANCE OF BRICK WITH THE CURRENT METHOD, UNLESS YOU FOLLOW THESE
 
 
 
-<div class="page__footer-copyright">© 2018 LukeHasAWii, <a href="https://www.dsiguide.me/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="https://dsiguide.me/site-navigation">Site Navigation</a>
+<div class="page__footer-copyright">© 2018 LukeHasAWii, <a href="/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="/site-navigation">Site Navigation</a>
 
       </div></footer>
     </div>

--- a/downgrading_(TempNand).html
+++ b/downgrading_(TempNand).html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- saved from url=(0031)https://dsiguide.me/downgrading -->
+<!-- saved from url=(0031)//downgrading -->
 <html lang="en" class=" js "><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     
 
@@ -28,8 +28,8 @@
 <meta property="og:title" content="Downgrading (ugopwn)">
 
 
-  <link rel="canonical" href="https://dsiguide.me/downgrading/">
-  <meta property="og:url" content="https://dsiguide.me/downgrading/">
+  <link rel="canonical" href="/downgrading/">
+  <meta property="og:url" content="/downgrading/">
 
 
 
@@ -56,7 +56,7 @@
       "@context" : "http://schema.org",
       "@type" : "Person",
       "name" : "LukeHasAWii",
-      "url" : "https://dsiguide.me",
+      "url" : "https://dsiguide.github.io",
       "sameAs" : null
     }
   </script>
@@ -80,7 +80,7 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="https://dsiguide.me/assets/css/main.css">
+<link rel="stylesheet" href="/assets/css/main.css">
 
 <meta http-equiv="cleartype" content="on">
 
@@ -89,16 +89,16 @@
 <!-- insert favicons. use http://realfavicongenerator.net/ -->
 
 <script type="text/javascript">
-    var host = "dsiguide.me";
+    var host = "dsiguide.github.io";
     if ((host == window.location.host) && (window.location.protocol != "https:"))
         window.location.protocol = "https";
 </script>
 
-<link rel="apple-touch-icon" sizes="180x180" href="https://dsiguide.me/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="https://dsiguide.me/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="https://dsiguide.me/favicon-16x16.png">
-<link rel="manifest" href="https://dsiguide.me/manifest.json">
-<link rel="mask-icon" href="https://dsiguide.me/safari-pinned-tab.svg" color="#5bbad5">
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+<link rel="manifest" href="/manifest.json">
+<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
 <meta name="theme-color" content="#ffffff">
 <!-- end custom head snippets -->
 
@@ -141,7 +141,7 @@
 
 
 
-<!--script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!--script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 <script>
   (adsbygoogle = window.adsbygoogle || []).push({
     google_ad_client: "ca-pub-6670011780914577",
@@ -180,13 +180,13 @@
 <div class="notice"><b>If you need help, ask the <a href="https://discord.gg/w4SKAr8">Nintendo DSiBrew Discord!</a></b></div>
         
           
-        <div class="notice"><b>I worked hard on this guide! If you want, you can <a href="https://dsiguide.me/donations">donate</a> through <a href="https://www.paypal.me/lukehasawii/10">PayPal</a> or <a href="bitcoin:126mXsRyQ8qmuqYQ86X3fhTvXL5B3SH877">Bitcoin</a>!</b></div>
+        <div class="notice"><b>I worked hard on this guide! If you want, you can <a href="/donations">donate</a> through <a href="https://www.paypal.me/lukehasawii/10">PayPal</a> or <a href="bitcoin:126mXsRyQ8qmuqYQ86X3fhTvXL5B3SH877">Bitcoin</a>!</b></div>
         
 
         <!--hr>
 
         <!--center>
-        <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
         <!-- Guide -->
         <!--ins class="adsbygoogle"
             style="display:block"
@@ -354,8 +354,8 @@ THERE IS A HIGH CHANCE OF BRICK WITH THE CURRENT METHOD, UNLESS YOU FOLLOW THESE
     
 </li></ol>
 
-<p class="notice--primary">Continue to <a href="https://dsiguide.me/hiyacfw-installation">Installing HiyaCFW</a>
-<p class="notice--primary">If you would like a way to access DSi Homebrew without having to use ugopwn every time, follow the procedure for <a href="https://dsiguide.me/exploit_installation.html">Installing exploitable DSiWare</a>
+<p class="notice--primary">Continue to <a href="/hiyacfw-installation">Installing HiyaCFW</a>
+<p class="notice--primary">If you would like a way to access DSi Homebrew without having to use ugopwn every time, follow the procedure for <a href="/exploit_installation.html">Installing exploitable DSiWare</a>
         <!--center>
         <ins class="adsbygoogle"
             style="display:block"
@@ -403,7 +403,7 @@ THERE IS A HIGH CHANCE OF BRICK WITH THE CURRENT METHOD, UNLESS YOU FOLLOW THESE
 
 
 
-<div class="page__footer-copyright">© 2018 LukeHasAWii, <a href="https://www.dsiguide.me/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="https://dsiguide.me/site-navigation">Site Navigation</a>
+<div class="page__footer-copyright">© 2018 LukeHasAWii, <a href="/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="/site-navigation">Site Navigation</a>
 
       </div></footer>
     </div>

--- a/dsiware-installation.html
+++ b/dsiware-installation.html
@@ -27,8 +27,8 @@
 <meta property="og:title" content="DSiWare installation">
 
 
-  <link rel="canonical" href="https://dsiguide.me/dsiware-installation/">
-  <meta property="og:url" content="https://dsiguide.me/dsiware-installation/">
+  <link rel="canonical" href="/dsiware-installation/">
+  <meta property="og:url" content="/dsiware-installation/">
 
 
 
@@ -55,7 +55,7 @@
       "@context" : "http://schema.org",
       "@type" : "Person",
       "name" : "LukeHasAWii",
-      "url" : "https://dsiguide.me",
+      "url" : "https://dsiguide.github.io",
       "sameAs" : null
     }
   </script>
@@ -88,16 +88,16 @@
 <!-- insert favicons. use http://realfavicongenerator.net/ -->
 
 <script type="text/javascript">
-    var host = "dsiguide.me";
+    var host = "dsiguide.github.io";
     if ((host == window.location.host) && (window.location.protocol != "https:"))
         window.location.protocol = "https";
 </script>
 
-<link rel="apple-touch-icon" sizes="180x180" href="https://dsiguide.me/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="https://dsiguide.me/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="https://dsiguide.me/favicon-16x16.png">
-<link rel="manifest" href="https://dsiguide.me/manifest.json">
-<link rel="mask-icon" href="https://dsiguide.me/safari-pinned-tab.svg" color="#5bbad5">
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+<link rel="manifest" href="/manifest.json">
+<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
 <meta name="theme-color" content="#ffffff">
 <!-- end custom head snippets -->
 
@@ -141,7 +141,7 @@
 
 
 
-<!--script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!--script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 <script>
   (adsbygoogle = window.adsbygoogle || []).push({
     google_ad_client: "ca-pub-6670011780914577",
@@ -175,7 +175,7 @@
 <div class="notice"><b>If you need help, ask the <a href="https://discord.gg/w4SKAr8">Nintendo DSiBrew Discord!</a></b></div>
         
           
-        <div class="notice"><b>I worked hard on this guide! If you want, you can <a href="https://dsiguide.me/donations">donate</a> through <a href="https://www.paypal.me/lukehasawii/10">PayPal</a></b></div>
+        <div class="notice"><b>I worked hard on this guide! If you want, you can <a href="/donations">donate</a> through <a href="https://www.paypal.me/lukehasawii/10">PayPal</a></b></div>
 	                          <p class="notice--info">Please read ALL below information before starting.</p>
 
 
@@ -278,7 +278,7 @@
 
 
 
-<div class="page__footer-copyright">© 2018 LukeHasAWii, <a href="https://www.dsiguide.me/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="https://dsiguide.me/site-navigation">Site Navigation</a>
+<div class="page__footer-copyright">© 2018 LukeHasAWii, <a href="/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="/site-navigation">Site Navigation</a>
 
       </div></footer>
     </div>

--- a/easy-sudokuhax.html
+++ b/easy-sudokuhax.html
@@ -27,8 +27,8 @@
 <meta property="og:title" content="Easy Sudokuhax Installation">
 
 
-  <link rel="canonical" href="https://dsiguide.me/easy-sudokuhax/">
-  <meta property="og:url" content="https://dsiguide.me/easy-sudokuhax/">
+  <link rel="canonical" href="/easy-sudokuhax/">
+  <meta property="og:url" content="/easy-sudokuhax/">
 
 
 
@@ -55,7 +55,7 @@
       "@context" : "http://schema.org",
       "@type" : "Person",
       "name" : "LukeHasAWii",
-      "url" : "https://dsiguide.me",
+      "url" : "https://dsiguide.github.io",
       "sameAs" : null
     }
   </script>
@@ -79,7 +79,7 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="https://dsiguide.me/assets/css/main.css">
+<link rel="stylesheet" href="/assets/css/main.css">
 
 <meta http-equiv="cleartype" content="on">
 
@@ -88,16 +88,16 @@
 <!-- insert favicons. use http://realfavicongenerator.net/ -->
 
 <script type="text/javascript">
-    var host = "dsiguide.me";
+    var host = "dsiguide.github.io";
     if ((host == window.location.host) && (window.location.protocol != "https:"))
         window.location.protocol = "https";
 </script>
 
-<link rel="apple-touch-icon" sizes="180x180" href="https://dsiguide.me/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="https://dsiguide.me/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="https://dsiguide.me/favicon-16x16.png">
-<link rel="manifest" href="https://dsiguide.me/manifest.json">
-<link rel="mask-icon" href="https://dsiguide.me/safari-pinned-tab.svg" color="#5bbad5">
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+<link rel="manifest" href="/manifest.json">
+<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
 <meta name="theme-color" content="#ffffff">
 <!-- end custom head snippets -->
 
@@ -141,7 +141,7 @@
 
 
 
-<!--script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!--script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 <script>
   (adsbygoogle = window.adsbygoogle || []).push({
     google_ad_client: "ca-pub-6670011780914577",
@@ -175,7 +175,7 @@
 <div class="notice"><b>If you need help, ask the <a href="https://discord.gg/w4SKAr8">Nintendo DSiBrew Discord!</a></b></div>
         
           
-        <div class="notice"><b>I worked hard on this guide! If you want, you can <a href="https://dsiguide.me/donations">donate</a> through <a href="https://www.paypal.me/lukehasawii/10">PayPal</a></b></div>
+        <div class="notice"><b>I worked hard on this guide! If you want, you can <a href="/donations">donate</a> through <a href="https://www.paypal.me/lukehasawii/10">PayPal</a></b></div>
 	                          <p class="notice--info">Please read ALL below information before starting.</p>
 
 
@@ -284,7 +284,7 @@
 
 
 
-<div class="page__footer-copyright">© 2018 LukeHasAWii, <a href="https://www.dsiguide.me/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="https://dsiguide.me/site-navigation">Site Navigation</a>
+<div class="page__footer-copyright">© 2018 LukeHasAWii, <a href="/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="/site-navigation">Site Navigation</a>
 
       </div></footer>
     </div>

--- a/exploit_installation.html
+++ b/exploit_installation.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- saved from url=(0031)https://dsiguide.me/downgrading -->
+<!-- saved from url=(0031)//downgrading -->
 <html lang="en" class=" js "><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     
 
@@ -28,8 +28,8 @@
 <meta property="og:title" content="Installing exploitable DSiWare">
 
 
-  <link rel="canonical" href="https://dsiguide.me/downgrading/">
-  <meta property="og:url" content="https://dsiguide.me/downgrading/">
+  <link rel="canonical" href="/downgrading/">
+  <meta property="og:url" content="/downgrading/">
 
 
 
@@ -56,7 +56,7 @@
       "@context" : "http://schema.org",
       "@type" : "Person",
       "name" : "LukeHasAWii",
-      "url" : "https://dsiguide.me",
+      "url" : "https://dsiguide.github.io",
       "sameAs" : null
     }
   </script>
@@ -80,7 +80,7 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="https://dsiguide.me/assets/css/main.css">
+<link rel="stylesheet" href="/assets/css/main.css">
 
 <meta http-equiv="cleartype" content="on">
 
@@ -89,16 +89,16 @@
 <!-- insert favicons. use http://realfavicongenerator.net/ -->
 
 <script type="text/javascript">
-    var host = "dsiguide.me";
+    var host = "dsiguide.github.io";
     if ((host == window.location.host) && (window.location.protocol != "https:"))
         window.location.protocol = "https";
 </script>
 
-<link rel="apple-touch-icon" sizes="180x180" href="https://dsiguide.me/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="https://dsiguide.me/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="https://dsiguide.me/favicon-16x16.png">
-<link rel="manifest" href="https://dsiguide.me/manifest.json">
-<link rel="mask-icon" href="https://dsiguide.me/safari-pinned-tab.svg" color="#5bbad5">
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+<link rel="manifest" href="/manifest.json">
+<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
 <meta name="theme-color" content="#ffffff">
 <!-- end custom head snippets -->
 
@@ -142,7 +142,7 @@
 
 
 
-<!--script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!--script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 <script>
   (adsbygoogle = window.adsbygoogle || []).push({
     google_ad_client: "ca-pub-6670011780914577",
@@ -181,14 +181,14 @@
 <div class="notice"><b>If you need help, ask the <a href="https://discord.gg/w4SKAr8">Nintendo DSiBrew Discord!</a></b></div>
         
           
-        <div class="notice"><b>I worked hard on this guide! If you want, you can <a href="https://dsiguide.me/donations">donate</a> through <a href="https://www.paypal.me/lukehasawii/10">PayPal</a> or <a href="bitcoin:126mXsRyQ8qmuqYQ86X3fhTvXL5B3SH877">Bitcoin</a>!</b></div>
+        <div class="notice"><b>I worked hard on this guide! If you want, you can <a href="/donations">donate</a> through <a href="https://www.paypal.me/lukehasawii/10">PayPal</a> or <a href="bitcoin:126mXsRyQ8qmuqYQ86X3fhTvXL5B3SH877">Bitcoin</a>!</b></div>
         
-<p class="notice--warning">This page still works fine, however, it is quite outdated and complicated. Follow <a href="https://dsiguide.me/easy-sudokuhax">here</a> for an updated Sudoku+sudokuhax guide. Sudokuhax is really the only exploit you need.</p>
+<p class="notice--warning">This page still works fine, however, it is quite outdated and complicated. Follow <a href="/easy-sudokuhax">here</a> for an updated Sudoku+sudokuhax guide. Sudokuhax is really the only exploit you need.</p>
 
         <!--hr>
 
         <!--center>
-        <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
         <!-- Guide -->
         <!--ins class="adsbygoogle"
             style="display:block"
@@ -370,7 +370,7 @@ JUST LIKE THE DOWNGRADE PROCEDURE, THIS PROCESS MAY RESULT IN A BRICK. MAKE SURE
     
 </li></ol>
 
-<p class="notice--primary">If you would like to check out what DSi Homebrew you can now use, check out <a href="https://dsiguide.me/homebrew-downloads">the Homebrew Downloads page.</a>
+<p class="notice--primary">If you would like to check out what DSi Homebrew you can now use, check out <a href="/homebrew-downloads">the Homebrew Downloads page.</a>
 
         <!--center>
         <ins class="adsbygoogle"
@@ -419,7 +419,7 @@ JUST LIKE THE DOWNGRADE PROCEDURE, THIS PROCESS MAY RESULT IN A BRICK. MAKE SURE
 
 
 
-<div class="page__footer-copyright">© 2018 LukeHasAWii, <a href="https://www.dsiguide.me/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="https://dsiguide.me/site-navigation">Site Navigation</a>
+<div class="page__footer-copyright">© 2018 LukeHasAWii, <a href="/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="/site-navigation">Site Navigation</a>
 
       </div></footer>
     </div>

--- a/exploit_installation_(TempNand).html
+++ b/exploit_installation_(TempNand).html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- saved from url=(0031)https://dsiguide.me/downgrading -->
+<!-- saved from url=(0031)//downgrading -->
 <html lang="en" class=" js "><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     
 
@@ -28,8 +28,8 @@
 <meta property="og:title" content="Installing exploitable DSiWare">
 
 
-  <link rel="canonical" href="https://dsiguide.me/downgrading/">
-  <meta property="og:url" content="https://dsiguide.me/downgrading/">
+  <link rel="canonical" href="/downgrading/">
+  <meta property="og:url" content="/downgrading/">
 
 
 
@@ -56,7 +56,7 @@
       "@context" : "http://schema.org",
       "@type" : "Person",
       "name" : "LukeHasAWii",
-      "url" : "https://dsiguide.me",
+      "url" : "https://dsiguide.github.io",
       "sameAs" : null
     }
   </script>
@@ -80,7 +80,7 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="https://dsiguide.me/assets/css/main.css">
+<link rel="stylesheet" href="/assets/css/main.css">
 
 <meta http-equiv="cleartype" content="on">
 
@@ -89,16 +89,16 @@
 <!-- insert favicons. use http://realfavicongenerator.net/ -->
 
 <script type="text/javascript">
-    var host = "dsiguide.me";
+    var host = "dsiguide.github.io";
     if ((host == window.location.host) && (window.location.protocol != "https:"))
         window.location.protocol = "https";
 </script>
 
-<link rel="apple-touch-icon" sizes="180x180" href="https://dsiguide.me/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="https://dsiguide.me/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="https://dsiguide.me/favicon-16x16.png">
-<link rel="manifest" href="https://dsiguide.me/manifest.json">
-<link rel="mask-icon" href="https://dsiguide.me/safari-pinned-tab.svg" color="#5bbad5">
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+<link rel="manifest" href="/manifest.json">
+<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
 <meta name="theme-color" content="#ffffff">
 <!-- end custom head snippets -->
 
@@ -142,7 +142,7 @@
 
 
 
-<!--script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!--script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 <script>
   (adsbygoogle = window.adsbygoogle || []).push({
     google_ad_client: "ca-pub-6670011780914577",
@@ -181,14 +181,14 @@
 <div class="notice"><b>If you need help, ask the <a href="https://discord.gg/w4SKAr8">Nintendo DSiBrew Discord!</a></b></div>
         
           
-        <div class="notice"><b>I worked hard on this guide! If you want, you can <a href="https://dsiguide.me/donations">donate</a> through <a href="https://www.paypal.me/lukehasawii/10">PayPal</a> or <a href="bitcoin:126mXsRyQ8qmuqYQ86X3fhTvXL5B3SH877">Bitcoin</a>!</b></div>
+        <div class="notice"><b>I worked hard on this guide! If you want, you can <a href="/donations">donate</a> through <a href="https://www.paypal.me/lukehasawii/10">PayPal</a> or <a href="bitcoin:126mXsRyQ8qmuqYQ86X3fhTvXL5B3SH877">Bitcoin</a>!</b></div>
         
-<p class="notice--warning">This page still works fine, however, it is quite outdated and complicated. Follow <a href="https://dsiguide.me/easy-sudokuhax">here</a> for an updated Sudoku+sudokuhax guide. Sudokuhax is really the only exploit you need.</p>
+<p class="notice--warning">This page still works fine, however, it is quite outdated and complicated. Follow <a href="/easy-sudokuhax">here</a> for an updated Sudoku+sudokuhax guide. Sudokuhax is really the only exploit you need.</p>
 
         <!--hr>
 
         <!--center>
-        <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
         <!-- Guide -->
         <!--ins class="adsbygoogle"
             style="display:block"
@@ -329,7 +329,7 @@ JUST LIKE THE DOWNGRADE PROCEDURE, THIS PROCESS MAY RESULT IN A BRICK. MAKE SURE
     
 </li></ol>
 
-<p class="notice--primary">If you would like to check out what DSi Homebrew you can now use, check out <a href="https://dsiguide.me/homebrew-downloads">the Homebrew Downloads page.</a>
+<p class="notice--primary">If you would like to check out what DSi Homebrew you can now use, check out <a href="/homebrew-downloads">the Homebrew Downloads page.</a>
 
         <!--center>
         <ins class="adsbygoogle"
@@ -378,7 +378,7 @@ JUST LIKE THE DOWNGRADE PROCEDURE, THIS PROCESS MAY RESULT IN A BRICK. MAKE SURE
 
 
 
-<div class="page__footer-copyright">© 2018 LukeHasAWii, <a href="https://www.dsiguide.me/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="https://dsiguide.me/site-navigation">Site Navigation</a>
+<div class="page__footer-copyright">© 2018 LukeHasAWii, <a href="/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="/site-navigation">Site Navigation</a>
 
       </div></footer>
     </div>

--- a/faq.html
+++ b/faq.html
@@ -28,8 +28,8 @@
 <meta property="og:title" content="FAQ">
 
 
-  <link rel="canonical" href="https://dsiguide.me/faq.html">
-  <meta property="og:url" content="https://dsiguide.me/faq.html">
+  <link rel="canonical" href="/faq.html">
+  <meta property="og:url" content="/faq.html">
 
 
 
@@ -56,7 +56,7 @@
       "@context" : "http://schema.org",
       "@type" : "Person",
       "name" : "LukeHasAWii",
-      "url" : "https://dsiguide.me",
+      "url" : "https://dsiguide.github.io",
       "sameAs" : null
     }
   </script>
@@ -82,7 +82,7 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="https://dsiguide.me/assets/css/main.css">
+<link rel="stylesheet" href="/assets/css/main.css">
 
 <meta http-equiv="cleartype" content="on">
 
@@ -91,7 +91,7 @@
 <!-- insert favicons, use http://realfavicongenerator.net/ -->
 
 <script type="text/javascript">
-    var host = "dsiguide.me";
+    var host = "dsiguide.github.io";
     if ((host == window.location.host) && (window.location.protocol != "https:"))
         window.location.protocol = "https";
 </script>
@@ -144,7 +144,7 @@
 
 
 
-<!--script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!--script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 <script>
   (adsbygoogle = window.adsbygoogle || []).push({
     google_ad_client: "ca-pub-6670011780914577",
@@ -189,7 +189,7 @@
         <hr>
 
         <!--center>
-        <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
         <!-- Guide -->
         <!--ins class="adsbygoogle"
             style="display:block"
@@ -298,12 +298,12 @@
 
 
 
-<div class="page__footer-copyright">&copy; 2018 LukeHasAWii, <a href="https://www.dsiguide.me/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
+<div class="page__footer-copyright">&copy; 2018 LukeHasAWii, <a href="/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
 
       </footer>
     </div>
 
-    <script src="https://dsiguide.me/assets/js/main.min.js"></script>
+    <script src="/assets/js/main.min.js"></script>
 
 
 

--- a/finalizing-setup.html
+++ b/finalizing-setup.html
@@ -27,8 +27,8 @@
 <meta property="og:title" content="Finalizing Setup">
 
 
-  <link rel="canonical" href="https://dsiguide.me/finalizing-setup.html">
-  <meta property="og:url" content="https://dsiguide.me/finalizing-setup.html">
+  <link rel="canonical" href="/finalizing-setup.html">
+  <meta property="og:url" content="/finalizing-setup.html">
 
 
 
@@ -55,7 +55,7 @@
       "@context" : "http://schema.org",
       "@type" : "Person",
       "name" : "LukeHasAWii",
-      "url" : "https://dsiguide.me",
+      "url" : "https://dsiguide.github.io",
       "sameAs" : null
     }
   </script>
@@ -81,7 +81,7 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="https://dsiguide.me/assets/css/main.css">
+<link rel="stylesheet" href="/assets/css/main.css">
 
 <meta http-equiv="cleartype" content="on">
 
@@ -90,7 +90,7 @@
 <!-- insert favicons, use http://realfavicongenerator.net/ -->
 
 <script type="text/javascript">
-    var host = "dsiguide.me";
+    var host = "dsiguide.github.io";
     if ((host == window.location.host) && (window.location.protocol != "https:"))
         window.location.protocol = "https";
 </script>
@@ -144,7 +144,7 @@
 
 
 
-<!--script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!--script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 <script>
   (adsbygoogle = window.adsbygoogle || []).push({
     google_ad_client: "ca-pub-6670011780914577",
@@ -193,7 +193,7 @@
 		<!-- add content here -->
 		
         <!--center>
-        <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
         <!-- Guide -->
         <!--ins class="adsbygoogle"
             style="display:block"
@@ -261,12 +261,12 @@
 
 
 
-<div class="page__footer-copyright">© 2017 LukeHasAWii, <a href="https://www.dsiguide.me/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
+<div class="page__footer-copyright">© 2017 LukeHasAWii, <a href="/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
 
       </div></footer>
     </div>
 
-    <script src="https://dsiguide.me/assets/js/main.min.js"></script>
+    <script src="/assets/js/main.min.js"></script>
 
 
 

--- a/get-started.html
+++ b/get-started.html
@@ -28,8 +28,8 @@
 <meta property="og:title" content="Get Started">
 
 
-  <link rel="canonical" href="https://dsiguide.me/get-started.html">
-  <meta property="og:url" content="https://dsiguide.me/get-started.html">
+  <link rel="canonical" href="/get-started.html">
+  <meta property="og:url" content="/get-started.html">
 
 
 
@@ -55,7 +55,7 @@
       "@context" : "http://schema.org",
       "@type" : "Person",
       "name" : "Plailect",
-      "url" : "https://dsiguide.me",
+      "url" : "https://dsiguide.github.io",
       "sameAs" : null
     }
   </script>
@@ -80,7 +80,7 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="https://dsiguide.me/assets/css/main.css">
+<link rel="stylesheet" href="/assets/css/main.css">
 
 <meta http-equiv="cleartype" content="on">
 
@@ -89,7 +89,7 @@
 <!-- insert favicons. use http://realfavicongenerator.net/ -->
 
 <script type="text/javascript">
-    var host = "dsiguide.me";
+    var host = "dsiguide.github.io";
     if ((host == window.location.host) && (window.location.protocol != "https:"))
         window.location.protocol = "https";
 </script>
@@ -141,7 +141,7 @@
 
 
 
-<!--script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!--script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 <script>
   (adsbygoogle = window.adsbygoogle || []).push({
     google_ad_client: "ca-pub-6670011780914577",
@@ -186,7 +186,7 @@
         <!--hr>
 
         <!--center>
-        <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
         <!-- Guide -->
         <!--ins class="adsbygoogle"
             style="display:block"
@@ -291,12 +291,12 @@
 
 
 
-<div class="page__footer-copyright">&copy; 2018 LukeHasAWii, <a href="https://www.dsiguide.me/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
+<div class="page__footer-copyright">&copy; 2018 LukeHasAWii, <a href="/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
 
       </footer>
     </div>
 
-    <script src="https://dsiguide.me/assets/js/main.min.js"></script>
+    <script src="/assets/js/main.min.js"></script>
 
 
 

--- a/hiyacfw-installation.html
+++ b/hiyacfw-installation.html
@@ -28,8 +28,8 @@
 <meta property="og:title" content="HiyaCFW installation">
 
 
-  <link rel="canonical" href="https://dsiguide.me/hiyacfw-installation.html">
-  <meta property="og:url" content="https://dsiguide.me/hiyacfw-installation.html">
+  <link rel="canonical" href="/hiyacfw-installation.html">
+  <meta property="og:url" content="/hiyacfw-installation.html">
 
 
 
@@ -56,7 +56,7 @@
       "@context" : "http://schema.org",
       "@type" : "Person",
       "name" : "LukeHasAWii",
-      "url" : "https://dsiguide.me",
+      "url" : "https://dsiguide.github.io",
       "sameAs" : null
     }
   </script>
@@ -82,7 +82,7 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="https://dsiguide.me/assets/css/main.css">
+<link rel="stylesheet" href="/assets/css/main.css">
 
 <meta http-equiv="cleartype" content="on">
 
@@ -91,7 +91,7 @@
 <!-- insert favicons. use http://realfavicongenerator.net/ -->
 
 <script type="text/javascript">
-    var host = "dsiguide.me";
+    var host = "dsiguide.github.io";
     if ((host == window.location.host) && (window.location.protocol != "https:"))
         window.location.protocol = "https";
 </script>
@@ -144,7 +144,7 @@
 
 
 
-<!--script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!--script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 <script>
   (adsbygoogle = window.adsbygoogle || []).push({
     google_ad_client: "ca-pub-6670011780914577",
@@ -189,7 +189,7 @@
         <!--hr>
 
         <!--center>
-        <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
         <!-- Guide -->
         <!--ins class="adsbygoogle"
             style="display:block"
@@ -257,12 +257,12 @@
 
 
 
-<div class="page__footer-copyright">&copy; 2018 LukeHasAWii, <a href="https://www.dsiguide.me/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
+<div class="page__footer-copyright">&copy; 2018 LukeHasAWii, <a href="/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
 
       </footer>
     </div>
 
-    <script src="https://dsiguide.me/assets/js/main.min.js"></script>
+    <script src="/assets/js/main.min.js"></script>
 
 
 

--- a/homebrew-downloads.html
+++ b/homebrew-downloads.html
@@ -28,8 +28,8 @@
 <meta property="og:title" content="Homebrew Downloads">
 
 
-  <link rel="canonical" href="https://dsiguide.me/homebrew-downloads.html">
-  <meta property="og:url" content="https://dsiguide.me/homebrew-downloads.html">
+  <link rel="canonical" href="/homebrew-downloads.html">
+  <meta property="og:url" content="/homebrew-downloads.html">
 
 
 
@@ -56,7 +56,7 @@
       "@context" : "http://schema.org",
       "@type" : "Person",
       "name" : "LukeHasAWii",
-      "url" : "https://dsiguide.me",
+      "url" : "https://dsiguide.github.io",
       "sameAs" : null
     }
   </script>
@@ -80,7 +80,7 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="https://dsiguide.me/assets/css/main.css">
+<link rel="stylesheet" href="/assets/css/main.css">
 
 <meta http-equiv="cleartype" content="on">
 
@@ -89,7 +89,7 @@
 <!-- insert favicons. use http://realfavicongenerator.net/ -->
 
 <script type="text/javascript">
-    var host = "dsiguide.me";
+    var host = "dsiguide.github.io";
     if ((host == window.location.host) && (window.location.protocol != "https:"))
         window.location.protocol = "https";
 </script>
@@ -169,7 +169,7 @@
   <li><a href="https://github.com/dsiguide/dsiguide.github.io/raw/master/files/cquake.zip" target="_blank">Cquake - Quake, Ported to DSi!</a></li>
   <li><a href="https://github.com/dsiguide/dsiguide.github.io/raw/master/files/DSx86.nds" target="_blank">DSx86 - A DOS Emulator for DSi! Compatibility may vary.</a></li>
   <li><a href="https://github.com/ApacheThunder/NesDS" target="_blank">NesDS (TWL) (bundled with SRLoader) - Github</a> or <a href="https://dsiguide.github.io\files\nesTWL.nds" target="_blank">Direct .nds</a></li>
-  <li><a href="https://dsiguide.me/files/Colors.nds" target="_blank">Colors - DS(i) Paint Tool</a></li>
+  <li><a href="/files/Colors.nds" target="_blank">Colors - DS(i) Paint Tool</a></li>
 </ul>
 </div>
 
@@ -177,14 +177,14 @@
 <p><strong>PC Tools</strong></p>
 
 <ul>
-  <li><a href="https://dsiguide.me/files/DSiKeyGrabber.zip" target="_blank">A legal DSi Common Key Grabber!</a></li>
+  <li><a href="/files/DSiKeyGrabber.zip" target="_blank">A legal DSi Common Key Grabber!</a></li>
   <li><a href="https://github.com/Jimmy-Z/TWLbf/releases" target="_blank">TWLbf - Github</a></li>
-  <li><a href="https://dsiguide.me/files/DSi_Downgrader_MultiRegion_V2.1.zip" target="_blank">DSi Downgrader</a></li>
-  <li><a href="https://dsiguide.me/files/twltool-v1.6.zip" target="_blank">TWLTool</a></li>
-  <li><a href="https://dsiguide.me/files/TWLIt.exe" target="_blank">TWLit - TWLTool with a GUI</a></li>
-  <li><a href="https://dsiguide.me/files/dsi_jpeg_signature_tool.zip" target="_blank">DSi .jpg Signature Tool - Upload .jpg's to DSi</a></li>
-  <li><a href="https://dsiguide.me/files/tickCRYPT_v1.0.zip" target="_blank">tickCrypt - Transfer DSiWare from one console to another</a></li>
-  <li><a href="https://www.dsiguide.me/files/NUSDownloader_v19_DSi.zip" target="_blank">NUSDownloader DSi</a></li>
+  <li><a href="/files/DSi_Downgrader_MultiRegion_V2.1.zip" target="_blank">DSi Downgrader</a></li>
+  <li><a href="/files/twltool-v1.6.zip" target="_blank">TWLTool</a></li>
+  <li><a href="/files/TWLIt.exe" target="_blank">TWLit - TWLTool with a GUI</a></li>
+  <li><a href="/files/dsi_jpeg_signature_tool.zip" target="_blank">DSi .jpg Signature Tool - Upload .jpg's to DSi</a></li>
+  <li><a href="/files/tickCRYPT_v1.0.zip" target="_blank">tickCrypt - Transfer DSiWare from one console to another</a></li>
+  <li><a href="/files/NUSDownloader_v19_DSi.zip" target="_blank">NUSDownloader DSi</a></li>
 
 
 </ul>
@@ -195,10 +195,10 @@
 
 <ul>
   <li><a href="https://github.com/Robz8/SRLoader/releases" target="_blank">SRLoader - Loads retail/commercial and homebrew ROMs (via nds-bootstrap) - Github</a></li>
-  <li><a href="https://dsiguide.me/files/fwTool_1.6.zip" target="_blank">FWTool 1.6 - No Safety Checks</a></li>
+  <li><a href="/files/fwTool_1.6.zip" target="_blank">FWTool 1.6 - No Safety Checks</a></li>
   <li><a href="https://github.com/Nuck-TH/fwTool/releases" target="_blank">FWTool - Safety Checks - Github</a></li>
   <li><a href="http://gg.gg/6re39" target="_blank">Aura Launcher</a> - An alternative DSi homebrew launcher to HBMenu/Boot Retro/SRLoader</li>
-  <li><a href="https://dsiguide.me/files/Boot_Retro.nds" target="_blank">Boot Retro - HBMenu with DS menu skin</a></li>
+  <li><a href="/files/Boot_Retro.nds" target="_blank">Boot Retro - HBMenu with DS menu skin</a></li>
   <li><a href="https://github.com/billy-acuna/SRLSelector/releases" target="_blank">SRLSelector</a></li>
 </ul>
 </div>
@@ -239,12 +239,12 @@
 
 
 
-<div class="page__footer-copyright">&copy; 2018 LukeHasAWii, <a href="https://www.dsiguide.me/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
+<div class="page__footer-copyright">&copy; 2018 LukeHasAWii, <a href="/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
 
       </footer>
     </div>
 
-    <script src="https://dsiguide.me/assets/js/main.min.js"></script>
+    <script src="/assets/js/main.min.js"></script>
 
 
 

--- a/index.html
+++ b/index.html
@@ -28,8 +28,8 @@
 <meta property="og:title" content="DSi Guide">
 
 
-  <link rel="canonical" href="https://dsiguide.me/">
-  <meta property="og:url" content="https://dsiguide.me/">
+  <link rel="canonical" href="/">
+  <meta property="og:url" content="/">
 
 
 
@@ -57,7 +57,7 @@
       "@context" : "http://schema.org",
       "@type" : "Person",
       "name" : "LukeHasAWii",
-      "url" : "https://dsiguide.me",
+      "url" : "https://dsiguide.github.io",
       "sameAs" : null
     }
   </script>
@@ -85,7 +85,7 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="https://www.dsiguide.github.io/assets/css/main.css">
+<link rel="stylesheet" href="/assets/css/main.css">
 
 <meta http-equiv="cleartype" content="on">
 
@@ -94,7 +94,7 @@
 <!-- insert favicons. use http://realfavicongenerator.net/ -->
 
 <script type="text/javascript">
-    var host = "dsiguide.me";
+    var host = "dsiguide.github.io";
     if ((host == window.location.host) && (window.location.protocol != "https:"))
         window.location.protocol = "https";
 </script>
@@ -153,7 +153,7 @@
 
 
 <div class="page__hero--overlay"
-  style="background-color: #5e616c; background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url('https://dsiguide.me/images/home-page-feature.jpg');"
+  style="background-color: #5e616c; background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url('/images/home-page-feature.jpg');"
 >
   
     <div class="wrapper">
@@ -186,7 +186,7 @@
 
 
 
-<!--script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!--script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 <script>
   (adsbygoogle = window.adsbygoogle || []).push({
     google_ad_client: "ca-pub-6670011780914577",
@@ -222,7 +222,7 @@
 	  <!--hr>
 
       <center>
-      <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+      <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
       <!-- Guide -->
       <!--ins class="adsbygoogle"
           style="display:block"
@@ -308,12 +308,12 @@
 
 
 
-<div class="page__footer-copyright">&copy; 2018 LukeHasAWii, <a href="https://www.dsiguide.me/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
+<div class="page__footer-copyright">&copy; 2018 LukeHasAWii, <a href="/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
 
       </footer>
     </div>
 
-    <script src="https://www.dsiguide.github.io/assets/js/main.min.js"></script>
+    <script src="/assets/js/main.min.js"></script>
 
 
 

--- a/installing-4swordshax.html
+++ b/installing-4swordshax.html
@@ -27,8 +27,8 @@
 <meta property="og:title" content="Installing 4Swordshax">
 
 
-  <link rel="canonical" href="https://dsiguide.me/installing-4swordshax.html">
-  <meta property="og:url" content="https://dsiguide.me/installing-4swordshax.html">
+  <link rel="canonical" href="/installing-4swordshax.html">
+  <meta property="og:url" content="/installing-4swordshax.html">
 
 
 
@@ -55,7 +55,7 @@
       "@context" : "http://schema.org",
       "@type" : "Person",
       "name" : "LukeHasAWii",
-      "url" : "https://dsiguide.me",
+      "url" : "https://dsiguide.github.io",
       "sameAs" : null
     }
   </script>
@@ -81,7 +81,7 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="https://dsiguide.me/assets/css/main.css">
+<link rel="stylesheet" href="/assets/css/main.css">
 
 <meta http-equiv="cleartype" content="on">
 
@@ -90,7 +90,7 @@
 <!-- insert favicons, use http://realfavicongenerator.net/ -->
 
 <script type="text/javascript">
-    var host = "dsiguide.me";
+    var host = "dsiguide.github.io";
     if ((host == window.location.host) && (window.location.protocol != "https:"))
         window.location.protocol = "https";
 </script>
@@ -143,7 +143,7 @@
 
 
 
-<!--script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!--script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 <script>
   (adsbygoogle = window.adsbygoogle || []).push({
     google_ad_client: "ca-pub-6670011780914577",
@@ -190,7 +190,7 @@
         <hr>
           
         <!--center>
-        <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
         <!-- Guide -->
         <!--ins class="adsbygoogle"
             style="display:block"
@@ -258,12 +258,12 @@
 
 
 
-<div class="page__footer-copyright">© 2018 LukeHasAWii, <a href="https://www.dsiguide.me/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
+<div class="page__footer-copyright">© 2018 LukeHasAWii, <a href="/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
 
       </div></footer>
     </div>
 
-    <script src="https://dsiguide.me/assets/js/main.min.js"></script>
+    <script src="/assets/js/main.min.js"></script>
 
 
 

--- a/restoring.html
+++ b/restoring.html
@@ -27,8 +27,8 @@
 <meta property="og:title" content="Flashing backups">
 
 
-  <link rel="canonical" href="https://dsiguide.me/downgrading/">
-  <meta property="og:url" content="https://dsiguide.me/downgrading/">
+  <link rel="canonical" href="/downgrading/">
+  <meta property="og:url" content="/downgrading/">
 
 
 
@@ -55,7 +55,7 @@
       "@context" : "http://schema.org",
       "@type" : "Person",
       "name" : "LukeHasAWii",
-      "url" : "https://dsiguide.me",
+      "url" : "https://dsiguide.github.io",
       "sameAs" : null
     }
   </script>
@@ -79,7 +79,7 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="https://dsiguide.me/assets/css/main.css">
+<link rel="stylesheet" href="/assets/css/main.css">
 
 <meta http-equiv="cleartype" content="on">
 
@@ -88,16 +88,16 @@
 <!-- insert favicons. use http://realfavicongenerator.net/ -->
 
 <script type="text/javascript">
-    var host = "dsiguide.me";
+    var host = "dsiguide.github.io";
     if ((host == window.location.host) && (window.location.protocol != "https:"))
         window.location.protocol = "https";
 </script>
 
-<link rel="apple-touch-icon" sizes="180x180" href="https://dsiguide.me/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="https://dsiguide.me/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="https://dsiguide.me/favicon-16x16.png">
-<link rel="manifest" href="https://dsiguide.me/manifest.json">
-<link rel="mask-icon" href="https://dsiguide.me/safari-pinned-tab.svg" color="#5bbad5">
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+<link rel="manifest" href="/manifest.json">
+<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
 <meta name="theme-color" content="#ffffff">
 <!-- end custom head snippets -->
 
@@ -140,7 +140,7 @@
 
 
 
-<!--script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!--script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 <script>
   (adsbygoogle = window.adsbygoogle || []).push({
     google_ad_client: "ca-pub-6670011780914577",
@@ -179,13 +179,13 @@
 <div class="notice"><b>If you need help, ask the <a href="https://discord.gg/w4SKAr8">Nintendo DSiBrew Discord!</a></b></div>
         
           
-        <div class="notice"><b>I worked hard on this guide! If you want, you can <a href="https://dsiguide.me/donations">donate</a> through <a href="https://www.paypal.me/lukehasawii/10">PayPal</a> or <a href="bitcoin:126mXsRyQ8qmuqYQ86X3fhTvXL5B3SH877">Bitcoin</a>!</b></div>
+        <div class="notice"><b>I worked hard on this guide! If you want, you can <a href="/donations">donate</a> through <a href="https://www.paypal.me/lukehasawii/10">PayPal</a> or <a href="bitcoin:126mXsRyQ8qmuqYQ86X3fhTvXL5B3SH877">Bitcoin</a>!</b></div>
         
 
         <!--hr>
 
         <!--center>
-        <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
         <!-- Guide -->
         <!--ins class="adsbygoogle"
             style="display:block"
@@ -326,7 +326,7 @@
         </script>
 
         </center-->
-<p class="notice--primary">Continue to <a href="https://dsiguide.me/hiyacfw-installation">Installing HiyaCFW</a>
+<p class="notice--primary">Continue to <a href="/hiyacfw-installation">Installing HiyaCFW</a>
       </p></section>
 
       <footer class="page__meta">
@@ -362,7 +362,7 @@
 
 
 
-<div class="page__footer-copyright">© 2018 LukeHasAWii, <a href="https://www.dsiguide.me/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="https://dsiguide.me/site-navigation">Site Navigation</a>
+<div class="page__footer-copyright">© 2018 LukeHasAWii, <a href="/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="/site-navigation">Site Navigation</a>
 
       </div></footer>
     </div>

--- a/site-navigation.html
+++ b/site-navigation.html
@@ -28,8 +28,8 @@
 <meta property="og:title" content="Site Navigation">
 
 
-  <link rel="canonical" href="https://dsiguide.me/site-navigation.html">
-  <meta property="og:url" content="https://dsiguide.me/site-navigation.html">
+  <link rel="canonical" href="/site-navigation.html">
+  <meta property="og:url" content="/site-navigation.html">
 
 
 
@@ -56,7 +56,7 @@
       "@context" : "http://schema.org",
       "@type" : "Person",
       "name" : "LukeHasAWii",
-      "url" : "https://dsiguide.me",
+      "url" : "https://dsiguide.github.io",
       "sameAs" : null
     }
   </script>
@@ -80,7 +80,7 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="https://dsiguide.me/assets/css/main.css">
+<link rel="stylesheet" href="/assets/css/main.css">
 
 <meta http-equiv="cleartype" content="on">
 
@@ -89,7 +89,7 @@
 <!-- insert favicons. use http://realfavicongenerator.net/ -->
 
 <script type="text/javascript">
-    var host = "dsiguide.me";
+    var host = "dsiguide.github.io";
     if ((host == window.location.host) && (window.location.protocol != "https:"))
         window.location.protocol = "https";
 </script>
@@ -231,12 +231,12 @@
 
 
 
-<div class="page__footer-copyright">&copy; 2018 LukeHasAWii, <a href="https://www.dsiguide.me/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
+<div class="page__footer-copyright">&copy; 2018 LukeHasAWii, <a href="/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
 
       </footer>
     </div>
 
-    <script src="https://dsiguide.me/assets/js/main.min.js"></script>
+    <script src="/assets/js/main.min.js"></script>
 
 
 

--- a/soon.html
+++ b/soon.html
@@ -28,8 +28,8 @@
 <meta property="og:title" content="Coming Soon...">
 
 
-  <link rel="canonical" href="https://dsiguide.me/soon/">
-  <meta property="og:url" content="https://dsiguide.me/soon/">
+  <link rel="canonical" href="/soon/">
+  <meta property="og:url" content="/soon/">
 
 
 
@@ -56,7 +56,7 @@
       "@context" : "http://schema.org",
       "@type" : "Person",
       "name" : "LukeHasAWii",
-      "url" : "https://dsiguide.me",
+      "url" : "https://dsiguide.github.io",
       "sameAs" : null
     }
   </script>
@@ -80,7 +80,7 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="https://dsiguide.me/assets/css/main.css">
+<link rel="stylesheet" href="/assets/css/main.css">
 
 <meta http-equiv="cleartype" content="on">
 
@@ -89,7 +89,7 @@
 <!-- insert favicons. use http://realfavicongenerator.net/ -->
 
 <script type="text/javascript">
-    var host = "dsiguide.me";
+    var host = "dsiguide.github.io";
     if ((host == window.location.host) && (window.location.protocol != "https:"))
         window.location.protocol = "https";
 </script>
@@ -141,7 +141,7 @@
 
 
 
-<!--script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!--script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 <script>
   (adsbygoogle = window.adsbygoogle || []).push({
     google_ad_client: "ca-pub-6670011780914577",
@@ -182,7 +182,7 @@
         <!--hr>
 
         <!--center>
-        <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
         <!-- Guide -->
         <!--ins class="adsbygoogle"
             style="display:block"
@@ -250,12 +250,12 @@
 
 
 
-<div class="page__footer-copyright">&copy; 2018 LukeHasAWii, <a href="https://www.dsiguide.me/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
+<div class="page__footer-copyright">&copy; 2018 LukeHasAWii, <a href="/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
 
       </footer>
     </div>
 
-    <script src="https://dsiguide.me/assets/js/main.min.js"></script>
+    <script src="/assets/js/main.min.js"></script>
 
 
 

--- a/tempnand_setup.html
+++ b/tempnand_setup.html
@@ -27,8 +27,8 @@
 <meta property="og:title" content="Setting up TempNand (ugopwn)">
 
 
-  <link rel="canonical" href="https://dsiguide.me/downgrading/">
-  <meta property="og:url" content="https://dsiguide.me/downgrading/">
+  <link rel="canonical" href="/downgrading/">
+  <meta property="og:url" content="/downgrading/">
 
 
 
@@ -55,7 +55,7 @@
       "@context" : "http://schema.org",
       "@type" : "Person",
       "name" : "LukeHasAWii",
-      "url" : "https://dsiguide.me",
+      "url" : "https://dsiguide.github.io",
       "sameAs" : null
     }
   </script>
@@ -79,7 +79,7 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="https://dsiguide.me/assets/css/main.css">
+<link rel="stylesheet" href="/assets/css/main.css">
 
 <meta http-equiv="cleartype" content="on">
 
@@ -88,16 +88,16 @@
 <!-- insert favicons. use http://realfavicongenerator.net/ -->
 
 <script type="text/javascript">
-    var host = "dsiguide.me";
+    var host = "dsiguide.github.io";
     if ((host == window.location.host) && (window.location.protocol != "https:"))
         window.location.protocol = "https";
 </script>
 
-<link rel="apple-touch-icon" sizes="180x180" href="https://dsiguide.me/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="https://dsiguide.me/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="https://dsiguide.me/favicon-16x16.png">
-<link rel="manifest" href="https://dsiguide.me/manifest.json">
-<link rel="mask-icon" href="https://dsiguide.me/safari-pinned-tab.svg" color="#5bbad5">
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+<link rel="manifest" href="/manifest.json">
+<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
 <meta name="theme-color" content="#ffffff">
 <!-- end custom head snippets -->
 
@@ -140,7 +140,7 @@
 
 
 
-<!--script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!--script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 <script>
   (adsbygoogle = window.adsbygoogle || []).push({
     google_ad_client: "ca-pub-6670011780914577",
@@ -179,13 +179,13 @@
 <div class="notice"><b>If you need help, ask the <a href="https://discord.gg/w4SKAr8">Nintendo DSiBrew Discord!</a></b></div>
         
           
-        <div class="notice"><b>I worked hard on this guide! If you want, you can <a href="https://dsiguide.me/donations">donate</a> through <a href="https://www.paypal.me/lukehasawii/10">PayPal</a> or <a href="bitcoin:126mXsRyQ8qmuqYQ86X3fhTvXL5B3SH877">Bitcoin</a>!</b></div>
+        <div class="notice"><b>I worked hard on this guide! If you want, you can <a href="/donations">donate</a> through <a href="https://www.paypal.me/lukehasawii/10">PayPal</a> or <a href="bitcoin:126mXsRyQ8qmuqYQ86X3fhTvXL5B3SH877">Bitcoin</a>!</b></div>
         
 
         <!--hr>
 
         <!--center>
-        <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
         <!-- Guide -->
         <!--ins class="adsbygoogle"
             style="display:block"
@@ -355,7 +355,7 @@
 
 
 
-<div class="page__footer-copyright">© 2018 LukeHasAWii, <a href="https://www.dsiguide.me/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="https://dsiguide.me/site-navigation">Site Navigation</a>
+<div class="page__footer-copyright">© 2018 LukeHasAWii, <a href="/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="/site-navigation">Site Navigation</a>
 
       </div></footer>
     </div>

--- a/troubleshooting.html
+++ b/troubleshooting.html
@@ -28,8 +28,8 @@
 <meta property="og:title" content="Troubleshooting">
 
 
-  <link rel="canonical" href="https://dsiguide.me/troubleshooting.html">
-  <meta property="og:url" content="https://dsiguide.me/troubleshooting.html">
+  <link rel="canonical" href="/troubleshooting.html">
+  <meta property="og:url" content="/troubleshooting.html">
 
 
 
@@ -56,7 +56,7 @@
       "@context" : "http://schema.org",
       "@type" : "Person",
       "name" : "LukeHasAWii",
-      "url" : "https://dsiguide.me",
+      "url" : "https://dsiguide.github.io",
       "sameAs" : null
     }
   </script>
@@ -81,7 +81,7 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="https://dsiguide.me/assets/css/main.css">
+<link rel="stylesheet" href="/assets/css/main.css">
 
 <meta http-equiv="cleartype" content="on">
 
@@ -142,7 +142,7 @@
 
 
 
-<!--script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!--script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 <script>
   (adsbygoogle = window.adsbygoogle || []).push({
     google_ad_client: "ca-pub-6670011780914577",
@@ -187,7 +187,7 @@
         <!--hr>
 
         <center>
-        <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
         <!-- Guide -->
         <!--ins class="adsbygoogle"
             style="display:block"
@@ -302,12 +302,12 @@
 
 
 
-<div class="page__footer-copyright">&copy; 2018 LukeHasAWii, <a href="https://www.dsiguide.me/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
+<div class="page__footer-copyright">&copy; 2018 LukeHasAWii, <a href="/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
 
       </footer>
     </div>
 
-    <script src="https://dsiguide.me/assets/js/main.min.js"></script>
+    <script src="/assets/js/main.min.js"></script>
 
 
 

--- a/uninstall-cfw.html
+++ b/uninstall-cfw.html
@@ -28,8 +28,8 @@
 <meta property="og:title" content="Uninstalling CFW">
 
 
-  <link rel="canonical" href="https://dsiguide.me/uninstall-cfw">
-  <meta property="og:url" content="https://dsiguide.me/uninstall-cfw">
+  <link rel="canonical" href="/uninstall-cfw">
+  <meta property="og:url" content="/uninstall-cfw">
 
 
 
@@ -56,7 +56,7 @@
       "@context" : "http://schema.org",
       "@type" : "Person",
       "name" : "LukeHasAWii",
-      "url" : "https://dsiguide.me",
+      "url" : "https://dsiguide.github.io",
       "sameAs" : null
     }
   </script>
@@ -80,7 +80,7 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="https://dsiguide.me/assets/css/main.css">
+<link rel="stylesheet" href="/assets/css/main.css">
 
 <meta http-equiv="cleartype" content="on">
 
@@ -89,7 +89,7 @@
 <!-- insert favicons. use http://realfavicongenerator.net/ -->
 
 <script type="text/javascript">
-    var host = "dsiguide.me";
+    var host = "dsiguide.github.io";
     if ((host == window.location.host) && (window.location.protocol != "https:"))
         window.location.protocol = "https";
 </script>
@@ -142,7 +142,7 @@
 
 
 
-<!--script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!--script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 <script>
   (adsbygoogle = window.adsbygoogle || []).push({
     google_ad_client: "ca-pub-6670011780914577",
@@ -183,7 +183,7 @@
         <!--hr>
 
         <!--center>
-        <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
         <!-- Guide -->
         <!--ins class="adsbygoogle"
             style="display:block"
@@ -251,12 +251,12 @@
 
 
 
-<div class="page__footer-copyright">&copy; 2017 LukeHasAWii, <a href="https://www.dsiguide.me/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
+<div class="page__footer-copyright">&copy; 2017 LukeHasAWii, <a href="/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
 
       </footer>
     </div>
 
-    <script src="https://dsiguide.me/assets/js/main.min.js"></script>
+    <script src="/assets/js/main.min.js"></script>
 
 
 

--- a/unlaunch_(TempNand).html
+++ b/unlaunch_(TempNand).html
@@ -27,8 +27,8 @@
 <meta property="og:title" content="Unlaunch (TempNand)">
 
 
-  <link rel="canonical" href="https://dsiguide.me/downgrading/">
-  <meta property="og:url" content="https://dsiguide.me/downgrading/">
+  <link rel="canonical" href="/downgrading/">
+  <meta property="og:url" content="/downgrading/">
 
 
 
@@ -55,7 +55,7 @@
       "@context" : "http://schema.org",
       "@type" : "Person",
       "name" : "LukeHasAWii",
-      "url" : "https://dsiguide.me",
+      "url" : "https://dsiguide.github.io",
       "sameAs" : null
     }
   </script>
@@ -79,7 +79,7 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="https://dsiguide.me/assets/css/main.css">
+<link rel="stylesheet" href="/assets/css/main.css">
 
 <meta http-equiv="cleartype" content="on">
 
@@ -88,16 +88,16 @@
 <!-- insert favicons. use http://realfavicongenerator.net/ -->
 
 <script type="text/javascript">
-    var host = "dsiguide.me";
+    var host = "dsiguide.github.io";
     if ((host == window.location.host) && (window.location.protocol != "https:"))
         window.location.protocol = "https";
 </script>
 
-<link rel="apple-touch-icon" sizes="180x180" href="https://dsiguide.me/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="https://dsiguide.me/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="https://dsiguide.me/favicon-16x16.png">
-<link rel="manifest" href="https://dsiguide.me/manifest.json">
-<link rel="mask-icon" href="https://dsiguide.me/safari-pinned-tab.svg" color="#5bbad5">
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+<link rel="manifest" href="/manifest.json">
+<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
 <meta name="theme-color" content="#ffffff">
 <!-- end custom head snippets -->
 
@@ -140,7 +140,7 @@
 
 
 
-<!--script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!--script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 <script>
   (adsbygoogle = window.adsbygoogle || []).push({
     google_ad_client: "ca-pub-6670011780914577",
@@ -179,13 +179,13 @@
 <div class="notice"><b>If you need help, ask the <a href="https://discord.gg/w4SKAr8">Nintendo DSiBrew Discord!</a></b></div>
         
           
-        <div class="notice"><b>I worked hard on this guide! If you want, you can <a href="https://dsiguide.me/donations">donate</a> through <a href="https://www.paypal.me/lukehasawii/10">PayPal</a> or <a href="bitcoin:126mXsRyQ8qmuqYQ86X3fhTvXL5B3SH877">Bitcoin</a>!</b></div>
+        <div class="notice"><b>I worked hard on this guide! If you want, you can <a href="/donations">donate</a> through <a href="https://www.paypal.me/lukehasawii/10">PayPal</a> or <a href="bitcoin:126mXsRyQ8qmuqYQ86X3fhTvXL5B3SH877">Bitcoin</a>!</b></div>
         
 
         <!--hr>
 
         <!--center>
-        <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
         <!-- Guide -->
         <!--ins class="adsbygoogle"
             style="display:block"
@@ -263,7 +263,7 @@
  <h5 id="section-i---installing">Installing Unlaunch</h5>
   <hr>
 <ol>
-  <li>If you have not already, follow the instructions for <a href="https://dsiguide.me/tempnand_setup">setting up TempNand.</a></li>
+  <li>If you have not already, follow the instructions for <a href="/tempnand_setup">setting up TempNand.</a></li>
   <li>Download and open the latest release of unlaunch, and extract the unlaunch.dsi file </li>
   <li>Open TempNand and go to File > Open > Open Encrypted Nand. Once the file choosing window opens, navigate to your nand_dsi.bin file </li>
   <li>Wait a few seconds for your TempNand to load your nand backup. </li>
@@ -275,7 +275,7 @@
   
 </li></ol>
 
-<p class="notice--primary">Continue to <a href="https://dsiguide.me/restoring">Testing and Restoring backups (TempNand & NO$GBA) </a>
+<p class="notice--primary">Continue to <a href="/restoring">Testing and Restoring backups (TempNand & NO$GBA) </a>
         <!--center>
         <ins class="adsbygoogle"
             style="display:block"
@@ -323,7 +323,7 @@
 
 
 
-<div class="page__footer-copyright">© 2018 LukeHasAWii, <a href="https://www.dsiguide.me/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="https://dsiguide.me/site-navigation">Site Navigation</a>
+<div class="page__footer-copyright">© 2018 LukeHasAWii, <a href="/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="/site-navigation">Site Navigation</a>
 
       </div></footer>
     </div>

--- a/updating.html
+++ b/updating.html
@@ -28,8 +28,8 @@
 <meta property="og:title" content="HiyaCFW (Upgrading)">
 
 
-  <link rel="canonical" href="https://dsiguide.me/updating/">
-  <meta property="og:url" content="https://dsiguide.me/updating/">
+  <link rel="canonical" href="/updating/">
+  <meta property="og:url" content="/updating/">
 
 
 
@@ -56,7 +56,7 @@
       "@context" : "http://schema.org",
       "@type" : "Person",
       "name" : "LukeHasAWii",
-      "url" : "https://dsiguide.me",
+      "url" : "https://dsiguide.github.io",
       "sameAs" : null
     }
   </script>
@@ -80,7 +80,7 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="https://dsiguide.me/assets/css/main.css">
+<link rel="stylesheet" href="/assets/css/main.css">
 
 <meta http-equiv="cleartype" content="on">
 
@@ -89,7 +89,7 @@
 <!-- insert favicons. use http://realfavicongenerator.net/ -->
 
 <script type="text/javascript">
-    var host = "dsiguide.me";
+    var host = "dsiguide.github.io";
     if ((host == window.location.host) && (window.location.protocol != "https:"))
         window.location.protocol = "https";
 </script>
@@ -142,7 +142,7 @@
 
 
 
-<!--script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!--script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 <script>
   (adsbygoogle = window.adsbygoogle || []).push({
     google_ad_client: "ca-pub-6670011780914577",
@@ -187,7 +187,7 @@
         <!--hr>
 
         <!--center>
-        <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
         <!-- Guide -->
         <!--ins class="adsbygoogle"
             style="display:block"
@@ -269,12 +269,12 @@
 
 
 
-<div class="page__footer-copyright">&copy; 2018 LukeHasAWii, <a href="https://www.dsiguide.me/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
+<div class="page__footer-copyright">&copy; 2018 LukeHasAWii, <a href="/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
 
       </footer>
     </div>
 
-    <script src="https://dsiguide.me/assets/js/main.min.js"></script>
+    <script src="/assets/js/main.min.js"></script>
 
 
 

--- a/waiting.html
+++ b/waiting.html
@@ -28,8 +28,8 @@
 <meta property="og:title" content="Waiting">
 
 
-  <link rel="canonical" href="https://dsiguide.me/waiting.html">
-  <meta property="og:url" content="https://dsiguide.me/waiting.html">
+  <link rel="canonical" href="/waiting.html">
+  <meta property="og:url" content="/waiting.html">
 
 
 
@@ -55,7 +55,7 @@
       "@context" : "http://schema.org",
       "@type" : "Person",
       "name" : "Plailect",
-      "url" : "https://dsiguide.me",
+      "url" : "https://dsiguide.github.io",
       "sameAs" : null
     }
   </script>
@@ -80,7 +80,7 @@
 </script>
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="https://dsiguide.me/assets/css/main.css">
+<link rel="stylesheet" href="/assets/css/main.css">
 
 <meta http-equiv="cleartype" content="on">
 
@@ -89,7 +89,7 @@
 <!-- insert favicons. use http://realfavicongenerator.net/ -->
 
 <script type="text/javascript">
-    var host = "dsiguide.me";
+    var host = "dsiguide.github.io";
     if ((host == window.location.host) && (window.location.protocol != "https:"))
         window.location.protocol = "https";
 </script>
@@ -142,7 +142,7 @@
 
 
 
-<!--script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!--script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 <script>
   (adsbygoogle = window.adsbygoogle || []).push({
     google_ad_client: "ca-pub-6670011780914577",
@@ -180,14 +180,14 @@
           
         
           
-        <div class ="notice"><b>HiyaCFW and RocketLauncher have been officially released! The developers of DSiGuide.me are working hard to write an up-to-date guide for usage of them, as soon as possible! Check back here soon!</b></div>
+        <div class ="notice"><b>HiyaCFW and RocketLauncher have been officially released! The developers of dsiguide.github.io are working hard to write an up-to-date guide for usage of them, as soon as possible! Check back here soon!</b></div>
         
-        <div class ="notice"><b>Thank you for choosing DSiGuide.me. This page will be updated shortly.</b></div>
+        <div class ="notice"><b>Thank you for choosing dsiguide.github.io. This page will be updated shortly.</b></div>
 
         
 
         <!--center>
-        <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+        <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
         <!-- Guide -->
         <!--ins class="adsbygoogle"
             style="display:block"
@@ -201,7 +201,7 @@
 
         <hr>
 
-        <p class="notice--primary">The full guide at DSiGuide.me is currently <code class="highlighter-rouge">1%</code> done. Check back for updates.
+        <p class="notice--primary">The full guide at dsiguide.github.io is currently <code class="highlighter-rouge">1%</code> done. Check back for updates.
 		
 
 
@@ -240,12 +240,12 @@
 
 
 
-<div class="page__footer-copyright">&copy; 2017 LukeHasAWii, <a href="https://www.dsiguide.me/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
+<div class="page__footer-copyright">&copy; 2017 LukeHasAWii, <a href="/credits#Developers">Developers</a>, Site Design Plailect - <a href="https://github.com/dsiguide/dsiguide.github.io">Source</a> - <a href="site-navigation">Site Navigation</a>
 
       </footer>
     </div>
 
-    <script src="https://dsiguide.me/assets/js/main.min.js"></script>
+    <script src="/assets/js/main.min.js"></script>
 
 
 


### PR DESCRIPTION
Basically i replaced every instance of `https://www.dsiguide.me` with `/`

except in the readme, THe readme i just changed the "Visit guide here" link to match the github.io page

any other issues let me know